### PR TITLE
Use aeson 2.0

### DIFF
--- a/src/AWSLambda/Events/APIGateway.hs
+++ b/src/AWSLambda/Events/APIGateway.hs
@@ -27,6 +27,7 @@ module AWSLambda.Events.APIGateway where
 import           Control.Lens            hiding ((.=))
 import           Data.Aeson
 import           Data.Aeson.Casing       (aesonDrop, camelCase)
+import qualified Data.Aeson.KeyMap       as KeyMap
 import           Data.Aeson.TH           (deriveFromJSON)
 import           Data.Aeson.Embedded
 import           Data.Aeson.TextValue
@@ -104,7 +105,7 @@ instance FromJSON Authorizer where
     Authorizer
       <$> o .:? "principalId"
       <*> o .:? "claims" .!= mempty
-      <*> (pure $ HashMap.delete "principalId" $ HashMap.delete "claims" o)
+      <*> (pure $ KeyMap.delete "principalId" $ KeyMap.delete "claims" o)
 $(makeLenses ''Authorizer)
 
 data ProxyRequestContext = ProxyRequestContext

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,3 +17,7 @@ extra-deps:
       - lib/services/amazonka-sts # amazonka library depends on this
       - lib/services/amazonka-kinesis
       - lib/services/amazonka-s3
+  - aeson-2.0.1.0@sha256:8d6ca9d71a52c2148c7156cde09dc514ef192a41dce21e9bd32487e64a5b30f6,6245
+  - hashable-1.3.2.0@sha256:781a0947cfe1cd82e51854cdb56ed10ed662a53e78041fd6f4fb88d04cab5c16,4039
+  - semialign-1.2.0.1@sha256:0e179b4d3a8eff79001d374d6c91917c6221696b9620f0a4d86852fc6a9b9501,2836
+  - time-compat-1.9.6.1@sha256:42d8f2e08e965e1718917d54ad69e1d06bd4b87d66c41dc7410f59313dba4ed1,5033

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -69,6 +69,34 @@ packages:
   original:
     subdir: lib/services/amazonka-s3
     url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+- completed:
+    hackage: aeson-2.0.1.0@sha256:8d6ca9d71a52c2148c7156cde09dc514ef192a41dce21e9bd32487e64a5b30f6,6245
+    pantry-tree:
+      size: 37910
+      sha256: 4c19385d42f07cd8a3b9b9540b3778cece89bdb7c8d89a08a82041dd9c249154
+  original:
+    hackage: aeson-2.0.1.0@sha256:8d6ca9d71a52c2148c7156cde09dc514ef192a41dce21e9bd32487e64a5b30f6,6245
+- completed:
+    hackage: hashable-1.3.2.0@sha256:781a0947cfe1cd82e51854cdb56ed10ed662a53e78041fd6f4fb88d04cab5c16,4039
+    pantry-tree:
+      size: 1050
+      sha256: feac33ec82252aebedd8669541c4570971769f6a0911243009c2074eb0133b16
+  original:
+    hackage: hashable-1.3.2.0@sha256:781a0947cfe1cd82e51854cdb56ed10ed662a53e78041fd6f4fb88d04cab5c16,4039
+- completed:
+    hackage: semialign-1.2.0.1@sha256:0e179b4d3a8eff79001d374d6c91917c6221696b9620f0a4d86852fc6a9b9501,2836
+    pantry-tree:
+      size: 537
+      sha256: 635bbbb517f0c063a4bc2e9e6efdb0e598b9d9fd467f52df81ab3a4af1fd923b
+  original:
+    hackage: semialign-1.2.0.1@sha256:0e179b4d3a8eff79001d374d6c91917c6221696b9620f0a4d86852fc6a9b9501,2836
+- completed:
+    hackage: time-compat-1.9.6.1@sha256:42d8f2e08e965e1718917d54ad69e1d06bd4b87d66c41dc7410f59313dba4ed1,5033
+    pantry-tree:
+      size: 4113
+      sha256: b262c5ae8d72d2073d12e1de1863abd234fad8c138df28f32bb51bc232ced608
+  original:
+    hackage: time-compat-1.9.6.1@sha256:42d8f2e08e965e1718917d54ad69e1d06bd4b87d66c41dc7410f59313dba4ed1,5033
 snapshots:
 - completed:
     size: 587126

--- a/test/AWSLambda/Events/APIGatewaySpec.hs
+++ b/test/AWSLambda/Events/APIGatewaySpec.hs
@@ -7,6 +7,7 @@ import           AWSLambda.Events.APIGateway
 
 import           Control.Lens
 import           Data.Aeson
+import qualified Data.Aeson.KeyMap           as KeyMap
 import           Data.ByteString.Lazy        (ByteString)
 import qualified Data.HashMap.Strict         as HashMap
 import           Data.IP
@@ -154,8 +155,8 @@ sampleGetRequest =
     , _prcAuthorizer =
       Just Authorizer
       { _aPrincipalId = Just "test-principalId"
-      , _aClaims = HashMap.fromList [("email", toJSON ("test@example.com" :: Text)), ("email_verified", toJSON True)]
-      , _aContext = HashMap.fromList [("custom_context", toJSON (10 :: Int))]
+      , _aClaims = KeyMap.fromList [("email", toJSON ("test@example.com" :: Text)), ("email_verified", toJSON True)]
+      , _aContext = KeyMap.fromList [("custom_context", toJSON (10 :: Int))]
       }
       
     }


### PR DESCRIPTION
Just a small update to use aeson 2.0.1.0 😀

Changes the references from `HashMap` to `KeyMap` as required by version 2.