### PR TITLE
Jan/upgrade to amazonka 2.0 rc1

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -13,9 +13,9 @@ dependencies:
   - base >= 4.7 && < 5
   - aeson
   - aeson-casing
-  - amazonka-core
-  - amazonka-kinesis
-  - amazonka-s3
+  - amazonka-core ^>= 2.0
+  - amazonka-kinesis ^>= 2.0
+  - amazonka-s3 ^>= 2.0
   - bytestring
   - case-insensitive
   - containers

--- a/src/AWSLambda/Events/APIGateway.hs
+++ b/src/AWSLambda/Events/APIGateway.hs
@@ -28,7 +28,6 @@ import           Control.Lens            hiding ((.=))
 import           Data.Aeson
 import           Data.Aeson.Casing       (aesonDrop, camelCase)
 import           Data.Aeson.TH           (deriveFromJSON)
--- import           Data.CaseInsensitive (CI (..))
 import           Data.Aeson.Embedded
 import           Data.Aeson.TextValue
 import           Data.Aeson.Types        (Parser)
@@ -42,8 +41,8 @@ import qualified Data.Set                as Set
 import qualified Data.Text               as Text
 import           Data.Text.Encoding      (decodeUtf8, encodeUtf8)
 import           GHC.Generics            (Generic)
-import           Network.AWS.Data.Base64
-import           Network.AWS.Data.Text
+import           Amazonka.Data.Base64
+import           Amazonka.Data.Text
 import qualified Network.HTTP.Types      as HTTP
 import           Text.Read
 

--- a/src/AWSLambda/Events/KinesisEvent.hs
+++ b/src/AWSLambda/Events/KinesisEvent.hs
@@ -15,9 +15,9 @@ import           Data.Aeson                (FromJSON (..), withObject, (.:))
 import           Data.Aeson.Casing         (aesonDrop, camelCase)
 import           Data.Aeson.TH             (deriveFromJSON)
 import           Data.Text                 (Text)
-import           Network.AWS.Data.Base64   (Base64 (..))
-import qualified Network.AWS.Kinesis.Types as Kinesis
-import qualified Network.AWS.Types         as AWS
+import           Amazonka.Data.Base64      (Base64 (..))
+import qualified Amazonka.Kinesis.Types    as Kinesis
+import qualified Amazonka.Types            as AWS
 
 import           AWSLambda.Events.Records
 
@@ -33,7 +33,7 @@ instance FromJSON KinesisRecord where
       _krKinesisSchemaVersion <- o .: "kinesisSchemaVersion"
       dataBase64 <- o .: "data"
       _krRecord <-
-        Kinesis.record <$> (o .: "sequenceNumber") <*> pure (unBase64 dataBase64) <*>
+        Kinesis.newRecord <$> (o .: "sequenceNumber") <*> pure (unBase64 dataBase64) <*>
         (o .: "partitionKey")
       return KinesisRecord {..}
 $(makeLenses ''KinesisRecord)

--- a/src/AWSLambda/Events/S3Event.hs
+++ b/src/AWSLambda/Events/S3Event.hs
@@ -18,8 +18,8 @@ import           Data.Aeson.Casing        (aesonDrop, camelCase)
 import           Data.Aeson.TH            (deriveFromJSON)
 import           Data.Text                (Text)
 import           Data.Time.Clock          (UTCTime)
-import           Network.AWS.S3           (BucketName, ETag, Event(..), ObjectKey, ObjectVersionId)
-import qualified Network.AWS.Types        as AWS
+import           Amazonka.S3              (BucketName, ETag, Event(..), ObjectKey, ObjectVersionId)
+import qualified Amazonka.Types           as AWS
 
 import           AWSLambda.Events.Records
 import           AWSLambda.Orphans        ()
@@ -112,25 +112,44 @@ type S3Event = RecordsEvent S3EventNotification
 -- | Is the event an object creation event
 isCreateEvent :: S3EventNotification -> Bool
 isCreateEvent e = case _senEventName e of
-  S3ObjectCreated -> True
-  S3ObjectCreatedCompleteMultipartUpload -> True
-  S3ObjectCreatedCopy -> True
-  S3ObjectCreatedPost -> True
-  S3ObjectCreatedPut -> True
-  S3ObjectRemoved -> False
-  S3ObjectRemovedDelete -> False
-  S3ObjectRemovedDeleteMarkerCreated -> False
-  S3ReducedRedundancyLostObject -> False
+  Event_S3_ObjectCreated_CompleteMultipartUpload -> True
+  Event_S3_ObjectCreated_Copy -> True
+  Event_S3_ObjectCreated_Post -> True
+  Event_S3_ObjectCreated_Put -> True
+  Event_S3_ObjectCreated__ -> True
+  Event_S3_ObjectRemoved_Delete -> False
+  Event_S3_ObjectRemoved_DeleteMarkerCreated -> False
+  Event_S3_ObjectRemoved__ -> False
+  Event_S3_ObjectRestore_Completed -> False
+  Event_S3_ObjectRestore_Post -> False
+  Event_S3_ObjectRestore__ -> False
+  Event_S3_ReducedRedundancyLostObject -> False
+  Event_S3_Replication_OperationFailedReplication -> False
+  Event_S3_Replication_OperationMissedThreshold -> False
+  Event_S3_Replication_OperationNotTracked -> False
+  Event_S3_Replication_OperationReplicatedAfterThreshold -> False
+  Event_S3_Replication__ -> False
+  Event' _ -> False
+
 
 -- | Is the event an object removal event
 isRemoveEvent :: S3EventNotification -> Bool
 isRemoveEvent e = case _senEventName e of
-  S3ObjectCreated -> False
-  S3ObjectCreatedCompleteMultipartUpload -> False
-  S3ObjectCreatedCopy -> False
-  S3ObjectCreatedPost -> False
-  S3ObjectCreatedPut -> False
-  S3ObjectRemoved -> True
-  S3ObjectRemovedDelete -> True
-  S3ObjectRemovedDeleteMarkerCreated -> True
-  S3ReducedRedundancyLostObject -> False
+  Event_S3_ObjectCreated_CompleteMultipartUpload -> False
+  Event_S3_ObjectCreated_Copy -> False
+  Event_S3_ObjectCreated_Post -> False
+  Event_S3_ObjectCreated_Put -> False
+  Event_S3_ObjectCreated__ -> False
+  Event_S3_ObjectRemoved_Delete -> True
+  Event_S3_ObjectRemoved_DeleteMarkerCreated -> True
+  Event_S3_ObjectRemoved__ -> True
+  Event_S3_ObjectRestore_Completed -> False
+  Event_S3_ObjectRestore_Post -> False
+  Event_S3_ObjectRestore__ -> False
+  Event_S3_ReducedRedundancyLostObject -> False
+  Event_S3_Replication_OperationFailedReplication -> False
+  Event_S3_Replication_OperationMissedThreshold -> False
+  Event_S3_Replication_OperationNotTracked -> False
+  Event_S3_Replication_OperationReplicatedAfterThreshold -> False
+  Event_S3_Replication__ -> False
+  Event' _ -> False

--- a/src/AWSLambda/Events/SNSEvent.hs
+++ b/src/AWSLambda/Events/SNSEvent.hs
@@ -25,8 +25,8 @@ import           Data.HashMap.Strict (HashMap)
 import           Data.Text (Text)
 import           Data.Time.Clock (UTCTime)
 import           GHC.Generics (Generic)
-import           Network.AWS.Data.Base64
-import           Network.AWS.Data.Text (FromText)
+import           Amazonka.Data.Base64
+import           Amazonka.Data.Text (FromText)
 
 import           AWSLambda.Events.MessageAttribute
 import           AWSLambda.Events.Records

--- a/src/AWSLambda/Events/SQSEvent.hs
+++ b/src/AWSLambda/Events/SQSEvent.hs
@@ -20,9 +20,9 @@ import           Data.ByteString (ByteString)
 import           Data.HashMap.Strict (HashMap)
 import           Data.Text (Text)
 import           GHC.Generics (Generic)
-import           Network.AWS.Data.Base64
-import           Network.AWS.Data.Text (FromText)
-import qualified Network.AWS.Types as AWS
+import           Amazonka.Data.Base64
+import           Amazonka.Data.Text (FromText)
+import qualified Amazonka.Types as AWS
 
 import           AWSLambda.Events.MessageAttribute
 import           AWSLambda.Events.Records

--- a/src/AWSLambda/Orphans.hs
+++ b/src/AWSLambda/Orphans.hs
@@ -6,10 +6,8 @@
 module AWSLambda.Orphans where
 
 import           Data.Aeson
-import           Data.Monoid           ((<>))
-import qualified Data.Text             as Text
-import           Network.AWS.Data.Text (fromText)
-import qualified Network.AWS.S3        as S3
+import           Amazonka.Data.Text (fromText)
+import qualified Amazonka.S3        as S3
 
 #if !MIN_VERSION_amazonka_core(1,6,0)
 deriving instance FromJSON S3.BucketName
@@ -21,12 +19,3 @@ deriving instance FromJSON S3.ObjectVersionId
 
 instance FromJSON S3.ETag where
   parseJSON = withText "ETag" $ either fail return . fromText
-
-instance FromJSON S3.Event where
-  parseJSON = withText "Event" $ either fail return . fromText . addS3Prefix
-    where
-      s3Prefix = "s3:"
-      addS3Prefix s =
-        if s3Prefix `Text.isPrefixOf` s
-          then s
-          else s3Prefix <> s

--- a/src/Data/Aeson/Embedded.hs
+++ b/src/Data/Aeson/Embedded.hs
@@ -12,17 +12,16 @@ module Data.Aeson.Embedded where
 import           Control.Lens.TH
 import           Data.Aeson
 import qualified Data.ByteString.Lazy as LBS
-import           Data.Text.Encoding    (decodeUtf8, encodeUtf8)
-import           Network.AWS.Data.Text (FromText (..), ToText (..), fromText,
-                                        takeText)
+import           Data.Text.Encoding   (decodeUtf8, encodeUtf8)
+import           Amazonka.Data.Text   (FromText (..), ToText (..), fromText)
 
 -- | Type for a JSON value embedded within a JSON string value
 newtype Embedded a = Embedded { _unEmbed :: a } deriving (Eq, Show)
 
 instance FromJSON a =>
          FromText (Embedded a) where
-  parser =
-    fmap Embedded . either fail pure . eitherDecodeStrict . encodeUtf8 =<< takeText
+  fromText txt =
+    fmap Embedded . eitherDecodeStrict $ encodeUtf8 txt
 
 instance FromJSON a =>
          FromJSON (Embedded a) where

--- a/src/Data/Aeson/TextValue.hs
+++ b/src/Data/Aeson/TextValue.hs
@@ -17,7 +17,7 @@ module Data.Aeson.TextValue where
 import           Control.Lens.TH
 import           Data.Aeson
 import           Data.String
-import           Network.AWS.Data.Text (FromText (..), ToText (..), fromText)
+import           Amazonka.Data.Text (FromText (..), ToText (..), fromText)
 
 
 newtype TextValue a = TextValue { _unTextValue :: a } deriving (Eq, Show, IsString)

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,7 +10,7 @@ nix:
 save-hackage-creds: false
 extra-deps:
   - github: brendanhay/amazonka
-    commit: e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c
+    commit: 098795f847df7239af64535c6b2b233f3fbd699c
     subdirs:
       - lib/amazonka
       - lib/amazonka-core

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,7 +10,7 @@ nix:
 save-hackage-creds: false
 extra-deps:
   - github: brendanhay/amazonka
-    commit: 19e6dca8485b7b8f74c564b7e38389b1d5b59e22
+    commit: e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c
     subdirs:
       - lib/amazonka
       - lib/amazonka-core

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,19 @@
-resolver: lts-17.7
+resolver: lts-18.8
 packages:
-- .
-- example-project
+  - .
+  - example-project
 nix:
   packages:
     - zlib.dev
     - zlib.out
 # Work around https://github.com/commercialhaskell/stack/issues/5290
 save-hackage-creds: false
+extra-deps:
+  - github: brendanhay/amazonka
+    commit: 19e6dca8485b7b8f74c564b7e38389b1d5b59e22
+    subdirs:
+      - lib/amazonka
+      - lib/amazonka-core
+      - lib/services/amazonka-sts # amazonka library depends on this
+      - lib/services/amazonka-kinesis
+      - lib/services/amazonka-s3

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,75 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    size: 26673790
+    subdir: lib/amazonka
+    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+    name: amazonka
+    version: '2.0'
+    sha256: 08e651aeaa36baf1e5fb41cd21fc1367f0e47ce05593a14ab8baef4f5b457918
+    pantry-tree:
+      size: 827
+      sha256: 2789ec3422222681e81d7c1b9b9f4f1ccf8dc2bf5d6feb2a9fd8fc249556edbc
+  original:
+    subdir: lib/amazonka
+    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+- completed:
+    size: 26673790
+    subdir: lib/amazonka-core
+    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+    name: amazonka-core
+    version: '2.0'
+    sha256: 08e651aeaa36baf1e5fb41cd21fc1367f0e47ce05593a14ab8baef4f5b457918
+    pantry-tree:
+      size: 3117
+      sha256: 7062a01c0cdd8538a388b56ddfc35725c9d2222c4d44d933cbb3bfa0eda670c1
+  original:
+    subdir: lib/amazonka-core
+    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+- completed:
+    size: 26673790
+    subdir: lib/services/amazonka-sts
+    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+    name: amazonka-sts
+    version: '2.0'
+    sha256: 08e651aeaa36baf1e5fb41cd21fc1367f0e47ce05593a14ab8baef4f5b457918
+    pantry-tree:
+      size: 2932
+      sha256: cab234646c792a272ac2d7011c34fe06902a466900d953c85ffff4e3faaa1378
+  original:
+    subdir: lib/services/amazonka-sts
+    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+- completed:
+    size: 26673790
+    subdir: lib/services/amazonka-kinesis
+    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+    name: amazonka-kinesis
+    version: '2.0'
+    sha256: 08e651aeaa36baf1e5fb41cd21fc1367f0e47ce05593a14ab8baef4f5b457918
+    pantry-tree:
+      size: 9299
+      sha256: 905a3bd9d8ff39a19a602615dffcf8280b8734187f875058f8aa9de1f86a145e
+  original:
+    subdir: lib/services/amazonka-kinesis
+    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+- completed:
+    size: 26673790
+    subdir: lib/services/amazonka-s3
+    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+    name: amazonka-s3
+    version: '2.0'
+    sha256: 08e651aeaa36baf1e5fb41cd21fc1367f0e47ce05593a14ab8baef4f5b457918
+    pantry-tree:
+      size: 37921
+      sha256: 6a643b1cf63b9fc3da9660d1682231dcea4c4157989ef60a414c7ecf67d2f1b0
+  original:
+    subdir: lib/services/amazonka-s3
+    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
 snapshots:
 - completed:
-    size: 565715
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/7.yaml
-    sha256: 1b5e4124989399e60e7a7901f0cefd910beea546131fb07a13a7208c4cc8b7ee
-  original: lts-17.7
+    size: 587126
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/8.yaml
+    sha256: 93a107557e8691ed5ca17beaee41e68222b142c48868fc8c04a4181fb233477d
+  original: lts-18.8

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,70 +5,70 @@
 
 packages:
 - completed:
-    size: 27715944
+    size: 27716899
     subdir: lib/amazonka
-    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/098795f847df7239af64535c6b2b233f3fbd699c.tar.gz
     name: amazonka
     version: '2.0'
-    sha256: 679fe14a2fac669eeeb56a5bcb688636cebde99b7974b12cad1832da0b3571ea
+    sha256: f78c31484748a9df89305ef998dab30018eb94f855fbb01b35d0680f10a52f8e
     pantry-tree:
       size: 1318
-      sha256: e331146cadd31d28d58d7adfd73aa32a665c39790abc57fd6253e17fa9a87542
+      sha256: 44fd392b7c986dd3417f70308741be397ca32b0d51f1ead3bc9d00505d5c8bcb
   original:
     subdir: lib/amazonka
-    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/098795f847df7239af64535c6b2b233f3fbd699c.tar.gz
 - completed:
-    size: 27715944
+    size: 27716899
     subdir: lib/amazonka-core
-    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/098795f847df7239af64535c6b2b233f3fbd699c.tar.gz
     name: amazonka-core
     version: '2.0'
-    sha256: 679fe14a2fac669eeeb56a5bcb688636cebde99b7974b12cad1832da0b3571ea
+    sha256: f78c31484748a9df89305ef998dab30018eb94f855fbb01b35d0680f10a52f8e
     pantry-tree:
       size: 3117
-      sha256: 3110e114014c4e3f2610c65bd9d8c8440bd78e3d6f8d07df8c6279c24d2c94ed
+      sha256: 7aacb4d572894018c2ee64ec3fcfeae802ad61a6b04b4da04e7477b72af3ca2c
   original:
     subdir: lib/amazonka-core
-    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/098795f847df7239af64535c6b2b233f3fbd699c.tar.gz
 - completed:
-    size: 27715944
+    size: 27716899
     subdir: lib/services/amazonka-sts
-    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/098795f847df7239af64535c6b2b233f3fbd699c.tar.gz
     name: amazonka-sts
     version: '2.0'
-    sha256: 679fe14a2fac669eeeb56a5bcb688636cebde99b7974b12cad1832da0b3571ea
+    sha256: f78c31484748a9df89305ef998dab30018eb94f855fbb01b35d0680f10a52f8e
     pantry-tree:
       size: 2932
       sha256: b3356be0b7999b0d4f0300b5f9bb61bb77090067e50140335210e817d30f9309
   original:
     subdir: lib/services/amazonka-sts
-    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/098795f847df7239af64535c6b2b233f3fbd699c.tar.gz
 - completed:
-    size: 27715944
+    size: 27716899
     subdir: lib/services/amazonka-kinesis
-    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/098795f847df7239af64535c6b2b233f3fbd699c.tar.gz
     name: amazonka-kinesis
     version: '2.0'
-    sha256: 679fe14a2fac669eeeb56a5bcb688636cebde99b7974b12cad1832da0b3571ea
+    sha256: f78c31484748a9df89305ef998dab30018eb94f855fbb01b35d0680f10a52f8e
     pantry-tree:
       size: 9301
       sha256: 562da1e73c6f965b47b4c9fe21337dba10fc96b85c05c1faaed36db08eb6cbf7
   original:
     subdir: lib/services/amazonka-kinesis
-    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/098795f847df7239af64535c6b2b233f3fbd699c.tar.gz
 - completed:
-    size: 27715944
+    size: 27716899
     subdir: lib/services/amazonka-s3
-    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/098795f847df7239af64535c6b2b233f3fbd699c.tar.gz
     name: amazonka-s3
     version: '2.0'
-    sha256: 679fe14a2fac669eeeb56a5bcb688636cebde99b7974b12cad1832da0b3571ea
+    sha256: f78c31484748a9df89305ef998dab30018eb94f855fbb01b35d0680f10a52f8e
     pantry-tree:
       size: 37929
       sha256: dae7759fe4c713a7932dcee0a993902fd9910c4a51e1655245a86892608af43e
   original:
     subdir: lib/services/amazonka-s3
-    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/098795f847df7239af64535c6b2b233f3fbd699c.tar.gz
 snapshots:
 - completed:
     size: 587126

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,70 +5,70 @@
 
 packages:
 - completed:
-    size: 26673790
+    size: 27715944
     subdir: lib/amazonka
-    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
     name: amazonka
     version: '2.0'
-    sha256: 08e651aeaa36baf1e5fb41cd21fc1367f0e47ce05593a14ab8baef4f5b457918
+    sha256: 679fe14a2fac669eeeb56a5bcb688636cebde99b7974b12cad1832da0b3571ea
     pantry-tree:
-      size: 827
-      sha256: 2789ec3422222681e81d7c1b9b9f4f1ccf8dc2bf5d6feb2a9fd8fc249556edbc
+      size: 1318
+      sha256: e331146cadd31d28d58d7adfd73aa32a665c39790abc57fd6253e17fa9a87542
   original:
     subdir: lib/amazonka
-    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
 - completed:
-    size: 26673790
+    size: 27715944
     subdir: lib/amazonka-core
-    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
     name: amazonka-core
     version: '2.0'
-    sha256: 08e651aeaa36baf1e5fb41cd21fc1367f0e47ce05593a14ab8baef4f5b457918
+    sha256: 679fe14a2fac669eeeb56a5bcb688636cebde99b7974b12cad1832da0b3571ea
     pantry-tree:
       size: 3117
-      sha256: 7062a01c0cdd8538a388b56ddfc35725c9d2222c4d44d933cbb3bfa0eda670c1
+      sha256: 3110e114014c4e3f2610c65bd9d8c8440bd78e3d6f8d07df8c6279c24d2c94ed
   original:
     subdir: lib/amazonka-core
-    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
 - completed:
-    size: 26673790
+    size: 27715944
     subdir: lib/services/amazonka-sts
-    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
     name: amazonka-sts
     version: '2.0'
-    sha256: 08e651aeaa36baf1e5fb41cd21fc1367f0e47ce05593a14ab8baef4f5b457918
+    sha256: 679fe14a2fac669eeeb56a5bcb688636cebde99b7974b12cad1832da0b3571ea
     pantry-tree:
       size: 2932
-      sha256: cab234646c792a272ac2d7011c34fe06902a466900d953c85ffff4e3faaa1378
+      sha256: b3356be0b7999b0d4f0300b5f9bb61bb77090067e50140335210e817d30f9309
   original:
     subdir: lib/services/amazonka-sts
-    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
 - completed:
-    size: 26673790
+    size: 27715944
     subdir: lib/services/amazonka-kinesis
-    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
     name: amazonka-kinesis
     version: '2.0'
-    sha256: 08e651aeaa36baf1e5fb41cd21fc1367f0e47ce05593a14ab8baef4f5b457918
+    sha256: 679fe14a2fac669eeeb56a5bcb688636cebde99b7974b12cad1832da0b3571ea
     pantry-tree:
-      size: 9299
-      sha256: 905a3bd9d8ff39a19a602615dffcf8280b8734187f875058f8aa9de1f86a145e
+      size: 9301
+      sha256: 562da1e73c6f965b47b4c9fe21337dba10fc96b85c05c1faaed36db08eb6cbf7
   original:
     subdir: lib/services/amazonka-kinesis
-    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
 - completed:
-    size: 26673790
+    size: 27715944
     subdir: lib/services/amazonka-s3
-    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
     name: amazonka-s3
     version: '2.0'
-    sha256: 08e651aeaa36baf1e5fb41cd21fc1367f0e47ce05593a14ab8baef4f5b457918
+    sha256: 679fe14a2fac669eeeb56a5bcb688636cebde99b7974b12cad1832da0b3571ea
     pantry-tree:
-      size: 37921
-      sha256: 6a643b1cf63b9fc3da9660d1682231dcea4c4157989ef60a414c7ecf67d2f1b0
+      size: 37929
+      sha256: dae7759fe4c713a7932dcee0a993902fd9910c4a51e1655245a86892608af43e
   original:
     subdir: lib/services/amazonka-s3
-    url: https://github.com/brendanhay/amazonka/archive/19e6dca8485b7b8f74c564b7e38389b1d5b59e22.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/e4fdf4a33e357942a6bc5bb6bfc133f18b56fa0c.tar.gz
 snapshots:
 - completed:
     size: 587126

--- a/test/AWSLambda/Events/KinesisEventSpec.hs
+++ b/test/AWSLambda/Events/KinesisEventSpec.hs
@@ -9,8 +9,8 @@ import           AWSLambda.Events.Records
 import           Data.Aeson
 import           Data.ByteString.Lazy          (ByteString)
 
-import qualified Network.AWS.Kinesis.Types     as Kinesis
-import           Network.AWS.Types             (Region (..))
+import qualified Amazonka.Kinesis.Types        as Kinesis
+import           Amazonka.Types                (Region (..))
 
 import           Text.RawString.QQ
 
@@ -52,7 +52,7 @@ sampleKinesisEvent =
       { _kerKinesis =
         KinesisRecord
         { _krRecord =
-          Kinesis.record
+          Kinesis.newRecord
             "49545115243490985018280067714973144582180062593244200961"
             "Hello, this is a test 123."
             "partitionKey-3"

--- a/test/AWSLambda/Events/S3EventSpec.hs
+++ b/test/AWSLambda/Events/S3EventSpec.hs
@@ -11,7 +11,7 @@ import           Data.ByteString.Lazy     (ByteString)
 import           Data.Time.Calendar
 import           Data.Time.Clock
 
-import           Network.AWS.S3
+import           Amazonka.S3
 
 import           Text.RawString.QQ
 
@@ -57,7 +57,7 @@ sampleS3PutJSON = [r|
         "x-amz-request-id": "EXAMPLE123456789"
       },
       "awsRegion": "us-east-1",
-      "eventName": "ObjectCreated:Put",
+      "eventName": "s3:ObjectCreated:Put",
       "userIdentity": {
         "principalId": "EXAMPLE"
       },
@@ -73,7 +73,7 @@ sampleS3PutEvent =
   { _reRecords =
     [ S3EventNotification
       { _senAwsRegion = NorthVirginia
-      , _senEventName = S3ObjectCreatedPut
+      , _senEventName = Event_S3_ObjectCreated_Put
       , _senEventSource = "aws:s3"
       , _senEventTime = UTCTime (fromGregorian 1970 1 1) (secondsToDiffTime 0)
       , _senEventVersion = "2.0"
@@ -147,7 +147,7 @@ sampleS3DeleteJSON = [r|
         "x-amz-request-id": "EXAMPLE123456789"
       },
       "awsRegion": "us-east-1",
-      "eventName": "ObjectRemoved:Delete",
+      "eventName": "s3:ObjectRemoved:Delete",
       "userIdentity": {
         "principalId": "EXAMPLE"
       },
@@ -163,7 +163,7 @@ sampleS3DeleteEvent =
   { _reRecords =
     [ S3EventNotification
       { _senAwsRegion = NorthVirginia
-      , _senEventName = S3ObjectRemovedDelete
+      , _senEventName = Event_S3_ObjectRemoved_Delete
       , _senEventSource = "aws:s3"
       , _senEventTime = UTCTime (fromGregorian 1970 1 1) (secondsToDiffTime 0)
       , _senEventVersion = "2.0"

--- a/test/AWSLambda/Events/SNSEventSpec.hs
+++ b/test/AWSLambda/Events/SNSEventSpec.hs
@@ -16,7 +16,7 @@ import qualified Data.HashMap.Strict       as HashMap
 import           Data.Text                 (Text)
 import           Data.Time.Calendar
 import           Data.Time.Clock
-import           Network.AWS.S3            as S3
+import           Amazonka.S3               as S3
 
 import           Text.RawString.QQ
 
@@ -113,7 +113,7 @@ sampleSNSS3JSON = [r|
         "MessageId":"89f6fe8b-a751-5dcd-8e0c-afbd75420455",
         "TopicArn":"arn:aws:sns:ap-southeast-2:012345678901:SomeSNSEvent",
         "Subject":"Amazon S3 Notification",
-        "Message": "{\"Records\":[{\"eventVersion\":\"2.0\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"ap-southeast-2\",\"eventTime\":\"2017-03-06T02:56:19.713Z\",\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AWS:DFLKSDFLKJ987SDFLJJDJ:some-principal-id\"},\"requestParameters\":{\"sourceIPAddress\":\"192.168.0.1\"},\"responseElements\":{\"x-amz-request-id\":\"324098EDFLK0894F\",\"x-amz-id-2\":\"xsdSDF/pgAl401Fz3UIATJ5/didfljDSFDSFsdfkjsdfl8JdsfLSDF89ldsf7SDF898jsdfljiA=\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"SomeS3Event:Created\",\"bucket\":{\"name\":\"some-bucket\",\"ownerIdentity\":{\"principalId\":\"A3O1SDFLKJIJXU\"},\"arn\":\"arn:aws:s3:::some-bucket\"},\"object\":{\"key\":\"path/to/some/object\",\"size\":53598442,\"eTag\":\"6b1f72b9e81e4d6fcd3e0c808e8477f8\",\"sequencer\":\"0058BCCFD25C798E7B\"}}}]}",
+        "Message": "{\"Records\":[{\"eventVersion\":\"2.0\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"ap-southeast-2\",\"eventTime\":\"2017-03-06T02:56:19.713Z\",\"eventName\":\"s3:ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"AWS:DFLKSDFLKJ987SDFLJJDJ:some-principal-id\"},\"requestParameters\":{\"sourceIPAddress\":\"192.168.0.1\"},\"responseElements\":{\"x-amz-request-id\":\"324098EDFLK0894F\",\"x-amz-id-2\":\"xsdSDF/pgAl401Fz3UIATJ5/didfljDSFDSFsdfkjsdfl8JdsfLSDF89ldsf7SDF898jsdfljiA=\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"SomeS3Event:Created\",\"bucket\":{\"name\":\"some-bucket\",\"ownerIdentity\":{\"principalId\":\"A3O1SDFLKJIJXU\"},\"arn\":\"arn:aws:s3:::some-bucket\"},\"object\":{\"key\":\"path/to/some/object\",\"size\":53598442,\"eTag\":\"6b1f72b9e81e4d6fcd3e0c808e8477f8\",\"sequencer\":\"0058BCCFD25C798E7B\"}}}]}",
         "Timestamp":"2017-03-06T02:56:19.834Z",
         "SignatureVersion":"1",
         "Signature":"aybEgnTjKzSbC2puHxho7SUnYOje4SjBoCyt0Q13bMWyp7M64+EU6jzi7P01+gSIuBFyYPsHreSmyqGMRSxbFuzn7rG5JcVGN0901U3CRXdk42eh03je8evRvs/Oa7TJlhpCTEDDOScalCWbIH0RthYONQpPR01nEgaNKj3e8YVJqyRQV+4RbU3YWJOj+Spyi4u1hOC9PLUv4BH7U80nbhbOe9EwgX0zpeNU1WBRbEpqPoACm+7/uB0w79qFBKjB/Q7OWc1kASUZV9q8bz03yceoQeVvza0QGhPsnSXi49sn1mLWQOFS4KvgbJIC/Qk7H036ShrDioP6pP+UEg6kow==",
@@ -146,7 +146,7 @@ sampleSNSS3Event =
               { _reRecords =
                 [ S3EventNotification
                   { _senAwsRegion = Sydney
-                  , _senEventName = S3ObjectCreatedPut
+                  , _senEventName = Event_S3_ObjectCreated_Put
                   , _senEventSource = "aws:s3"
                   , _senEventTime =
                     UTCTime

--- a/test/AWSLambda/Events/SQSEventSpec.hs
+++ b/test/AWSLambda/Events/SQSEventSpec.hs
@@ -14,7 +14,7 @@ import           Data.ByteString.Lazy              (ByteString)
 import           Data.Text                         (Text)
 import           Data.Time.Calendar
 import           Data.Time.Clock
-import           Network.AWS.S3                    as S3
+import           Amazonka.S3                       as S3
 
 import           Text.RawString.QQ
 
@@ -103,7 +103,7 @@ sampleS3SNSSQSJSON = [r|
     {
       "messageId": "b792b6ba-b444-48c5-9cd8-29b8ad373eae",
       "receiptHandle": "ReceiptHandle",
-      "body": "{\n  \"Type\" : \"Notification\",\n  \"MessageId\" : \"MessageId\",\n  \"TopicArn\" : \"arn:aws:sns:ap-southeast-2:11111111111111:my-topic\",\n  \"Subject\" : \"Amazon S3 Notification\",\n  \"Message\" : \"{\\\"Records\\\":[{\\\"eventVersion\\\":\\\"2.1\\\",\\\"eventSource\\\":\\\"aws:s3\\\",\\\"awsRegion\\\":\\\"ap-southeast-2\\\",\\\"eventTime\\\":\\\"2019-11-01T00:00:00.00Z\\\",\\\"eventName\\\":\\\"ObjectCreated:Put\\\",\\\"userIdentity\\\":{\\\"principalId\\\":\\\"AWS:AHJD568HF4356HJJ:bob\\\"},\\\"requestParameters\\\":{\\\"sourceIPAddress\\\":\\\"787.39.11.220\\\"},\\\"responseElements\\\":{\\\"x-amz-request-id\\\":\\\"GDJS6765sJSHSS\\\",\\\"x-amz-id-2\\\":\\\"ID2\\\"},\\\"s3\\\":{\\\"s3SchemaVersion\\\":\\\"1.0\\\",\\\"configurationId\\\":\\\"ConfigurationId\\\",\\\"bucket\\\":{\\\"name\\\":\\\"my-bucket\\\",\\\"ownerIdentity\\\":{\\\"principalId\\\":\\\"ASKD794UDYDH\\\"},\\\"arn\\\":\\\"arn:aws:s3:::my-bucket\\\"},\\\"object\\\":{\\\"key\\\":\\\"my-key\\\",\\\"size\\\":13315,\\\"eTag\\\":\\\"1231234fabf233124124\\\",\\\"versionId\\\":\\\"735hjf893ufb8fhuf\\\",\\\"sequencer\\\":\\\"HUJKFDHJD8656567HGGSGJKD\\\"}}}]}\",\n  \"Timestamp\" : \"2019-11-01T00:00:00Z\",\n  \"SignatureVersion\" : \"1\",\n  \"Signature\" : \"Signature\",\n  \"SigningCertURL\" : \"https://sns.ap-southeast-2.amazonaws.com/SimpleNotificationService-my-cert.pem\",\n  \"UnsubscribeURL\" : \"https://sns.ap-southeast-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:ap-southeast-2:11111111111111:my-topic:unsub\"\n}",
+      "body": "{\n  \"Type\" : \"Notification\",\n  \"MessageId\" : \"MessageId\",\n  \"TopicArn\" : \"arn:aws:sns:ap-southeast-2:11111111111111:my-topic\",\n  \"Subject\" : \"Amazon S3 Notification\",\n  \"Message\" : \"{\\\"Records\\\":[{\\\"eventVersion\\\":\\\"2.1\\\",\\\"eventSource\\\":\\\"aws:s3\\\",\\\"awsRegion\\\":\\\"ap-southeast-2\\\",\\\"eventTime\\\":\\\"2019-11-01T00:00:00.00Z\\\",\\\"eventName\\\":\\\"s3:ObjectCreated:Put\\\",\\\"userIdentity\\\":{\\\"principalId\\\":\\\"AWS:AHJD568HF4356HJJ:bob\\\"},\\\"requestParameters\\\":{\\\"sourceIPAddress\\\":\\\"787.39.11.220\\\"},\\\"responseElements\\\":{\\\"x-amz-request-id\\\":\\\"GDJS6765sJSHSS\\\",\\\"x-amz-id-2\\\":\\\"ID2\\\"},\\\"s3\\\":{\\\"s3SchemaVersion\\\":\\\"1.0\\\",\\\"configurationId\\\":\\\"ConfigurationId\\\",\\\"bucket\\\":{\\\"name\\\":\\\"my-bucket\\\",\\\"ownerIdentity\\\":{\\\"principalId\\\":\\\"ASKD794UDYDH\\\"},\\\"arn\\\":\\\"arn:aws:s3:::my-bucket\\\"},\\\"object\\\":{\\\"key\\\":\\\"my-key\\\",\\\"size\\\":13315,\\\"eTag\\\":\\\"1231234fabf233124124\\\",\\\"versionId\\\":\\\"735hjf893ufb8fhuf\\\",\\\"sequencer\\\":\\\"HUJKFDHJD8656567HGGSGJKD\\\"}}}]}\",\n  \"Timestamp\" : \"2019-11-01T00:00:00Z\",\n  \"SignatureVersion\" : \"1\",\n  \"Signature\" : \"Signature\",\n  \"SigningCertURL\" : \"https://sns.ap-southeast-2.amazonaws.com/SimpleNotificationService-my-cert.pem\",\n  \"UnsubscribeURL\" : \"https://sns.ap-southeast-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:ap-southeast-2:11111111111111:my-topic:unsub\"\n}",
       "attributes": {
         "ApproximateReceiveCount": "1",
         "SentTimestamp": "1572575717896",
@@ -140,7 +140,7 @@ sampleS3SNSSQSEvent =
             { _smMessage                = TextValue $ Embedded $ RecordsEvent
               [ S3EventNotification
                 { _senAwsRegion         = Sydney
-                , _senEventName         = S3ObjectCreatedPut
+                , _senEventName         = Event_S3_ObjectCreated_Put
                 , _senEventSource       = "aws:s3"
                 , _senEventTime         = UTCTime (fromGregorian 2019 11 1) 0
                 , _senEventVersion      = "2.1"


### PR DESCRIPTION
# Don't merge
This is just temporal branch to get rid of this stack warning before serverless-haskell switches to amazonka 2 and releases a new version to hackage.


DEPRECATED: The package at Archive from https://github.com/jhrcek/serverless-haskell/archive/bdd5f9ebed171fe23bbdec65392931ba0cbbc896.tar.gz does not include a cabal file.
Instead, it includes an hpack package.yaml file for generating a cabal file.
This usage is deprecated; please see https://github.com/commercialhaskell/stack/issues/5210.
Support for this workflow will be removed in the future.